### PR TITLE
Fix/for orange robot

### DIFF
--- a/include/livox_to_pointcloud2.hpp
+++ b/include/livox_to_pointcloud2.hpp
@@ -16,6 +16,9 @@ private:
     void callback(const livox_ros_driver2::msg::CustomMsg::SharedPtr msg);
     rclcpp::Subscription<livox_ros_driver2::msg::CustomMsg>::SharedPtr subscription_;
     rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr publisher_;
+
+    std::string pub_topic_;
+    std::string sub_topic_;
 };
 
 #endif  // LIVOX_TO_POINTCLOUD2_HPP

--- a/launch/livox_to_pointcloud2.launch.py
+++ b/launch/livox_to_pointcloud2.launch.py
@@ -1,0 +1,11 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            package='livox_to_pointcloud2',
+            executable='livox_to_pointcloud2_node',
+            name='livox_to_pointcloud2_node'
+        )
+    ])

--- a/launch/livox_to_pointcloud2.launch.xml
+++ b/launch/livox_to_pointcloud2.launch.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="use_sim_time" default="false"/>
+  
+  <node pkg="livox_to_pointcloud2" exec="livox_to_pointcloud2_node">
+    <param name="use_sim_time" value="$(var use_sim_time)"/>
+  </node>
+</launch>

--- a/src/livox_to_pointcloud2.cpp
+++ b/src/livox_to_pointcloud2.cpp
@@ -4,9 +4,12 @@ using namespace std::chrono_literals;
 
 LivoxToPointCloud2::LivoxToPointCloud2() : Node("livox_to_pointcloud2")
 {
-    publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("converted_pointcloud2", 10);
+    pub_topic_ = this->declare_parameter<std::string>("pub_topic", "/converted_pointcloud2");
+    sub_topic_ = this->declare_parameter<std::string>("sub_topic", "/livox/lidar");
+
+    publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(pub_topic_, 10);
     subscription_ = this->create_subscription<livox_ros_driver2::msg::CustomMsg>(
-        "livox_pointcloud", 10, std::bind(&LivoxToPointCloud2::callback, this, std::placeholders::_1));
+        sub_topic_, 10, std::bind(&LivoxToPointCloud2::callback, this, std::placeholders::_1));
 }
 
 void LivoxToPointCloud2::callback(const livox_ros_driver2::msg::CustomMsg::SharedPtr msg)


### PR DESCRIPTION
## PR Type
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Overview
- livox_to_pointcloud2をorange_robot用に修正しました。

## Detail
- xml形式とpython形式のlaunchファイルを追加しました。
- launchファイルでトピック名を変更しやすくしました。
- デフォルトのトピック名は以下の通りです。
Input topic : /livox/lidar
Output topic : /converted_pointcloud2

## Test
- [x] I have tested this change with rosbag

## Attention ⚠️ 
- 実際に使っていくにはdockerfileの方を修正する必要があるため、後々修正します。